### PR TITLE
Percentile-based plot scaling with outlier detection

### DIFF
--- a/Core/MeterManager.lua
+++ b/Core/MeterManager.lua
@@ -227,7 +227,7 @@ end
 function MeterManager:ToggleMeter(meterType)
     local meterInfo = registeredMeters[meterType]
     if not meterInfo then
-        -- Unknown meter type
+        -- Unknown meter type - fail silently
         return false
     end
     

--- a/STORMY.lua
+++ b/STORMY.lua
@@ -324,6 +324,8 @@ SlashCmdList["STORMY"] = function(msg)
         print("  /stormy debug - Show debug information")
         print("  /stormy reset - Reset statistics")
         print("  /stormy poolstats - Show pool statistics")
+        print("  /stormy plotscale <mode> - Set plot scaling (max|95th|90th|85th)")
+        print("  /stormy plotoutliers <on|off> - Toggle outlier indicators")
         print("  /stormy version - Show version")
     elseif command == "debug" then
         print("=== STORMY Debug Information ===")
@@ -380,6 +382,87 @@ SlashCmdList["STORMY"] = function(msg)
         if addon.TablePool then
             addon.TablePool:Debug()
         end
+    elseif command:match("^plotscale%s") then
+        -- Plot scaling configuration: /stormy plotscale percentile|max|95th|90th
+        local mode = command:match("^plotscale%s+(.+)")
+        if mode == "max" then
+            -- Use traditional max-value scaling
+            if addon.DPSPlot then
+                addon.DPSPlot.config.usePercentileScaling = false
+                print("[STORMY] DPS Plot: Using max-value scaling")
+            end
+            if addon.HPSPlot then
+                addon.HPSPlot.config.usePercentileScaling = false
+                print("[STORMY] HPS Plot: Using max-value scaling")
+            end
+        elseif mode == "percentile" or mode == "95th" then
+            -- Use 95th percentile scaling (default)
+            if addon.DPSPlot then
+                addon.DPSPlot.config.usePercentileScaling = true
+                addon.DPSPlot.config.scalePercentile = 0.95
+                print("[STORMY] DPS Plot: Using 95th percentile scaling")
+            end
+            if addon.HPSPlot then
+                addon.HPSPlot.config.usePercentileScaling = true
+                addon.HPSPlot.config.scalePercentile = 0.95
+                print("[STORMY] HPS Plot: Using 95th percentile scaling")
+            end
+        elseif mode == "90th" then
+            -- Use 90th percentile scaling
+            if addon.DPSPlot then
+                addon.DPSPlot.config.usePercentileScaling = true
+                addon.DPSPlot.config.scalePercentile = 0.90
+                print("[STORMY] DPS Plot: Using 90th percentile scaling")
+            end
+            if addon.HPSPlot then
+                addon.HPSPlot.config.usePercentileScaling = true
+                addon.HPSPlot.config.scalePercentile = 0.90
+                print("[STORMY] HPS Plot: Using 90th percentile scaling")
+            end
+        elseif mode == "85th" then
+            -- Use 85th percentile scaling (more aggressive outlier filtering)
+            if addon.DPSPlot then
+                addon.DPSPlot.config.usePercentileScaling = true
+                addon.DPSPlot.config.scalePercentile = 0.85
+                print("[STORMY] DPS Plot: Using 85th percentile scaling")
+            end
+            if addon.HPSPlot then
+                addon.HPSPlot.config.usePercentileScaling = true
+                addon.HPSPlot.config.scalePercentile = 0.85
+                print("[STORMY] HPS Plot: Using 85th percentile scaling")
+            end
+        else
+            print("[STORMY] Usage: /stormy plotscale <mode>")
+            print("  max     - Use maximum value for scaling (outliers affect scale)")
+            print("  95th    - Use 95th percentile (ignores top 5% outliers) [DEFAULT]")
+            print("  90th    - Use 90th percentile (ignores top 10% outliers)")
+            print("  85th    - Use 85th percentile (ignores top 15% outliers)")
+        end
+    elseif command:match("^plotoutliers%s") then
+        -- Outlier indicator toggle: /stormy plotoutliers on|off
+        local mode = command:match("^plotoutliers%s+(.+)")
+        if mode == "on" then
+            if addon.DPSPlot then
+                addon.DPSPlot.config.showOutlierIndicators = true
+                print("[STORMY] DPS Plot: Outlier indicators enabled")
+            end
+            if addon.HPSPlot then
+                addon.HPSPlot.config.showOutlierIndicators = true
+                print("[STORMY] HPS Plot: Outlier indicators enabled")
+            end
+        elseif mode == "off" then
+            if addon.DPSPlot then
+                addon.DPSPlot.config.showOutlierIndicators = false
+                print("[STORMY] DPS Plot: Outlier indicators disabled")
+            end
+            if addon.HPSPlot then
+                addon.HPSPlot.config.showOutlierIndicators = false
+                print("[STORMY] HPS Plot: Outlier indicators disabled")
+            end
+        else
+            print("[STORMY] Usage: /stormy plotoutliers <on|off>")
+            print("Shows visual indicators for bars that exceed 2x the scale value")
+        end
     else
         print("STORMY Commands:")
         print("  /stormy dps - Toggle DPS meter")
@@ -389,6 +472,8 @@ SlashCmdList["STORMY"] = function(msg)
         print("  /stormy debug - Show debug information")
         print("  /stormy reset - Reset statistics")
         print("  /stormy poolstats - Show pool statistics")
+        print("  /stormy plotscale <mode> - Set plot scaling (max|95th|90th|85th)")
+        print("  /stormy plotoutliers <on|off> - Toggle outlier indicators")
         print("  /stormy version - Show version")
     end
 end

--- a/STORMY.lua
+++ b/STORMY.lua
@@ -20,8 +20,8 @@ addon._buildHash = "20250628_" .. math.random(1000, 9999)
 -- =============================================================================
 
 addon.ADDON_NAME = addonName
-addon.VERSION = "1.0.0"
-addon.BUILD_DATE = "2025-06-28"
+addon.VERSION = "1.0.13"
+addon.BUILD_DATE = "2025-08-08"
 
 -- =============================================================================
 -- SAVED VARIABLES AND CONFIGURATION
@@ -389,10 +389,14 @@ SlashCmdList["STORMY"] = function(msg)
             -- Use traditional max-value scaling
             if addon.DPSPlot then
                 addon.DPSPlot.config.usePercentileScaling = false
+                -- Force immediate scale recalculation
+                addon.DPSPlot.lastScaleUpdate = 0
                 print("[STORMY] DPS Plot: Using max-value scaling")
             end
             if addon.HPSPlot then
                 addon.HPSPlot.config.usePercentileScaling = false
+                -- Force immediate scale recalculation
+                addon.HPSPlot.lastScaleUpdate = 0
                 print("[STORMY] HPS Plot: Using max-value scaling")
             end
         elseif mode == "percentile" or mode == "95th" then
@@ -400,11 +404,13 @@ SlashCmdList["STORMY"] = function(msg)
             if addon.DPSPlot then
                 addon.DPSPlot.config.usePercentileScaling = true
                 addon.DPSPlot.config.scalePercentile = 0.95
+                addon.DPSPlot.lastScaleUpdate = 0  -- Force recalc
                 print("[STORMY] DPS Plot: Using 95th percentile scaling")
             end
             if addon.HPSPlot then
                 addon.HPSPlot.config.usePercentileScaling = true
                 addon.HPSPlot.config.scalePercentile = 0.95
+                addon.HPSPlot.lastScaleUpdate = 0  -- Force recalc
                 print("[STORMY] HPS Plot: Using 95th percentile scaling")
             end
         elseif mode == "90th" then
@@ -412,11 +418,13 @@ SlashCmdList["STORMY"] = function(msg)
             if addon.DPSPlot then
                 addon.DPSPlot.config.usePercentileScaling = true
                 addon.DPSPlot.config.scalePercentile = 0.90
+                addon.DPSPlot.lastScaleUpdate = 0  -- Force recalc
                 print("[STORMY] DPS Plot: Using 90th percentile scaling")
             end
             if addon.HPSPlot then
                 addon.HPSPlot.config.usePercentileScaling = true
                 addon.HPSPlot.config.scalePercentile = 0.90
+                addon.HPSPlot.lastScaleUpdate = 0  -- Force recalc
                 print("[STORMY] HPS Plot: Using 90th percentile scaling")
             end
         elseif mode == "85th" then
@@ -424,11 +432,13 @@ SlashCmdList["STORMY"] = function(msg)
             if addon.DPSPlot then
                 addon.DPSPlot.config.usePercentileScaling = true
                 addon.DPSPlot.config.scalePercentile = 0.85
+                addon.DPSPlot.lastScaleUpdate = 0  -- Force recalc
                 print("[STORMY] DPS Plot: Using 85th percentile scaling")
             end
             if addon.HPSPlot then
                 addon.HPSPlot.config.usePercentileScaling = true
                 addon.HPSPlot.config.scalePercentile = 0.85
+                addon.HPSPlot.lastScaleUpdate = 0  -- Force recalc
                 print("[STORMY] HPS Plot: Using 85th percentile scaling")
             end
         else

--- a/STORMY.toc
+++ b/STORMY.toc
@@ -2,7 +2,7 @@
 ## Title: STORMY - Real-time Personal Damage Tracker
 ## Notes: High-performance damage tracking focused on player and pets with minimal overhead
 ## Author: You
-## Version: 1.0.12
+## Version: 1.0.13
 ## SavedVariables: StormyDB
 ## DefaultState: enabled
 ## OptionalDeps: Ace3, LibStub


### PR DESCRIPTION
## Summary
- Implements intelligent percentile-based scaling for DPS/HPS plots to handle extreme outliers
- Adds visual indicators and smooth transitions for outlier detection
- Provides user configuration options for scaling behavior

## Problem Solved
Previously, extreme outliers (like 25M Touch of Death spikes) would set the Y-axis scale so high that normal DPS patterns (1-2M) became invisible tiny bars at the bottom of the plot. This made the plots nearly useless during normal combat.

## Solution
- **95th percentile scaling**: By default, ignores the top 5% of values when calculating scale
- **Independent plot scaling**: DPS and HPS plots each maintain their own scale
- **Visual outlier indicators**: Bars that exceed the scale are capped with colored indicators (yellow for DPS, cyan for HPS)
- **Smart warmup**: Uses max scaling for first 10 data points or 5 seconds, then switches to percentile
- **Smooth transitions**: When bars become outliers, indicators fade in with a pulse effect

## New Commands
- `/stormy plotscale <mode>` - Set scaling mode:
  - `max` - Traditional max-value scaling (outliers affect scale)
  - `95th` - Use 95th percentile (default, ignores top 5%)
  - `90th` - Use 90th percentile (ignores top 10%)
  - `85th` - Use 85th percentile (ignores top 15%)
- `/stormy plotoutliers <on|off>` - Toggle visual outlier indicators

## Testing
Tested with real combat data including Touch of Death (25M spike) and normal rotation (1-2M DPS). The plots now remain readable and useful throughout combat while still acknowledging outliers with visual indicators.

## Screenshots
User provided screenshots showing the issue and confirming the fix works as intended.

🤖 Generated with [Claude Code](https://claude.ai/code)